### PR TITLE
Convert FiberNode data to a structure that can be used

### DIFF
--- a/extension/backend/dataCollection.ts
+++ b/extension/backend/dataCollection.ts
@@ -12,3 +12,49 @@ export const childOrSibling = (node) => {
 
   return infoObject;
 }
+  // STATE
+  // Check for hooks
+  // If memoizedState.memoizedState && _debugHookTypes = ['useState']
+  // Extract state labels from elementType - Need to convert function to string and extract
+
+  // Check for component state
+  // Check if tag === 1
+  // If so, memoizedState will be an object of key/value pairs of component state
+
+  // PROPS
+  // memoizedProps will be an object of key/value pairs of props
+  // We can also check tag to check for what type of component it is
+
+
+const convertStateProps = (obj) => {
+  // Create representations of state and prop which can be queried
+}
+
+const simplifyNode = (node) => {
+  // Change the structure of an individual node
+  // Remove unnecessary data
+}
+
+const convertStructure = (node) => {
+  // Convert dual linked list structure into graph
+  // Create a new node
+  const convertedNode = {};
+  convertedNode.value = node;
+  // Create a children array
+  convertedNode.children = [];
+  // Add child to array
+  if (!node.child) return convertedNode;
+  convertedNode.children.push(convertStructure(node.child));
+  // ConvertStructure() of each sibling and sibling of sibling etc. and add them to children array
+  let childNode = node.child;
+  while(childNode.sibling) {
+    convertedNode.children.push(convertStructure(childNode.sibling));
+    childNode = childNode.sibling;
+  }
+  // Return converted node
+  return convertedNode;
+}
+
+export const extractData = (node) => {
+  return convertStructure(node);
+}

--- a/extension/backend/dataCollection.ts
+++ b/extension/backend/dataCollection.ts
@@ -1,16 +1,20 @@
-export const childOrSibling = (node) => {
-  const memoizedState = node.memoizedState ? node.memoizedState.memoizedState : null;
-  const infoObject = {
-    id: node._debugID,
-    type: node.type,
-    memoizedState,
-    memoizedProps: node.memoizedProps,
-    tag: node.tag,
-  };
-  if (node.child) infoObject.child = childOrSibling(node.child);
-  if (node.sibling) infoObject.sibling = childOrSibling(node.sibling);
+import { 
+  DisplayNode,
+  State,
+} from './interfaces';
 
-  return infoObject;
+
+class SimpleNode implements DisplayNode {
+  id: number;
+  displayName: string;
+  tag: number;
+  props: State[] | null = null;
+  state: State[] | null = null;
+  children: DisplayNode[] = [];
+  constructor(node: any) {
+    this.id = node._debugID;
+    this.tag = node.tag;
+  }
 }
   // STATE
   // Check for hooks
@@ -24,24 +28,15 @@ export const childOrSibling = (node) => {
   // PROPS
   // memoizedProps will be an object of key/value pairs of props
   // We can also check tag to check for what type of component it is
-
-
+  
 const convertStateProps = (obj) => {
   // Create representations of state and prop which can be queried
-}
-
-const simplifyNode = (node) => {
-  // Change the structure of an individual node
-  // Remove unnecessary data
 }
 
 const convertStructure = (node) => {
   // Convert dual linked list structure into graph
   // Create a new node
-  const convertedNode = {};
-  convertedNode.value = node;
-  // Create a children array
-  convertedNode.children = [];
+  const convertedNode = new SimpleNode(node);
   // Add child to array
   if (!node.child) return convertedNode;
   convertedNode.children.push(convertStructure(node.child));

--- a/extension/backend/dataCollection.ts
+++ b/extension/backend/dataCollection.ts
@@ -8,9 +8,10 @@ class SimpleNode implements DisplayNode {
   id: number;
   displayName: string;
   tag: number;
-  props: State[] | null = null;
-  state: State[] | null = null;
+  props: State[] = [];
+  state: State[] = [];
   children: DisplayNode[] = [];
+  parent: string | null = null;
   constructor(node: any) {
     this.id = node._debugID;
     this.tag = node.tag;

--- a/extension/backend/dataCollection.ts
+++ b/extension/backend/dataCollection.ts
@@ -1,0 +1,14 @@
+export const childOrSibling = (node) => {
+  const memoizedState = node.memoizedState ? node.memoizedState.memoizedState : null;
+  const infoObject = {
+    id: node._debugID,
+    type: node.type,
+    memoizedState,
+    memoizedProps: node.memoizedProps,
+    tag: node.tag,
+  };
+  if (node.child) infoObject.child = childOrSibling(node.child);
+  if (node.sibling) infoObject.sibling = childOrSibling(node.sibling);
+
+  return infoObject;
+}

--- a/extension/backend/initialHook.ts
+++ b/extension/backend/initialHook.ts
@@ -1,3 +1,5 @@
+import { childOrSibling } from "./dataCollection";
+
 // dec variables to hold react global hook 
 //declare const window: any;
 declare global {
@@ -6,35 +8,37 @@ declare global {
   }
 }
 
-const devTools =  window.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+const devTools = window.__REACT_DEVTOOLS_GLOBAL_HOOK__;
 console.log('devTools: ', devTools)
 const reactInstance = window.__REACT_DEVTOOLS_GLOBAL_HOOK__.renderers;
 console.log('reactInstance: ', reactInstance)
 const instance = reactInstance.get(1);
 console.log('instance:', instance);
-console.log('testing');
+console.log('testingz');
 
 export const initialHook = () => {
 
-  if(instance && instance.version){
+  if (instance && instance.version) {
     let test;
     devTools.onCommitFiberRoot = (function (original) {
       return function (...args) {
         test = args[1].current;
         console.log('DOM: ', test);
+        console.log('TEST: ', childOrSibling(test));
         return original(...args);
       };
     })(devTools.onCommitFiberRoot);
-    } else if (instance && instance.Reconciler) {
-    instance.Reconciler.receiveComponent = (function (original) {
-      return function (...args) {
-          setTimeout(() => {
-            console.log(instance.reconciler);
-          }, 10);
-        return original(...args);
-      };
-    })(instance.Reconciler.receiveComponent); 
   }
+  // else if (instance && instance.Reconciler) {
+  //   instance.Reconciler.receiveComponent = (function (original) {
+  //     return function (...args) {
+  //       setTimeout(() => {
+  //         console.log(instance.reconciler);
+  //       }, 10);
+  //       return original(...args);
+  //     };
+  //   })(instance.Reconciler.receiveComponent);
+  // }
 }
 
 //export default initialHook;

--- a/extension/backend/initialHook.ts
+++ b/extension/backend/initialHook.ts
@@ -1,4 +1,3 @@
-import { childOrSibling } from "./dataCollection";
 import { extractData } from './dataCollection';
 
 // dec variables to hold react global hook 
@@ -10,12 +9,9 @@ declare global {
 }
 
 const devTools = window.__REACT_DEVTOOLS_GLOBAL_HOOK__;
-console.log('devTools: ', devTools)
 const reactInstance = window.__REACT_DEVTOOLS_GLOBAL_HOOK__.renderers;
-console.log('reactInstance: ', reactInstance)
 const instance = reactInstance.get(1);
-console.log('instance:', instance);
-console.log('testingz');
+
 
 export const initialHook = () => {
 
@@ -24,8 +20,8 @@ export const initialHook = () => {
     devTools.onCommitFiberRoot = (function (original) {
       return function (...args) {
         test = args[1].current;
+        // for debugging
         console.log('DOM: ', test);
-        // console.log('TEST: ', childOrSibling(test));
         console.log('Con: ', extractData(test));
         return original(...args);
       };

--- a/extension/backend/initialHook.ts
+++ b/extension/backend/initialHook.ts
@@ -1,4 +1,5 @@
 import { childOrSibling } from "./dataCollection";
+import { extractData } from './dataCollection';
 
 // dec variables to hold react global hook 
 //declare const window: any;
@@ -24,7 +25,8 @@ export const initialHook = () => {
       return function (...args) {
         test = args[1].current;
         console.log('DOM: ', test);
-        console.log('TEST: ', childOrSibling(test));
+        // console.log('TEST: ', childOrSibling(test));
+        console.log('Con: ', extractData(test));
         return original(...args);
       };
     })(devTools.onCommitFiberRoot);

--- a/extension/backend/interfaces.ts
+++ b/extension/backend/interfaces.ts
@@ -5,6 +5,7 @@ export interface DisplayNode {
   props: State[] | null,
   state: State[] | null,
   children: DisplayNode[] | null,
+  parent: string | null,
 }
 
 export interface State {

--- a/extension/backend/interfaces.ts
+++ b/extension/backend/interfaces.ts
@@ -1,0 +1,14 @@
+export interface FiberNode {
+  id: number,
+  displayName: string,
+  props: State[] | null,
+  state: State[] | null,
+  children: FiberNode[] | null,
+}
+
+export interface State {
+  key: string,
+  value: any,
+  topComponent: any,
+  components: any[],
+}

--- a/extension/backend/interfaces.ts
+++ b/extension/backend/interfaces.ts
@@ -1,10 +1,10 @@
 export interface DisplayNode {
   id: number,
   displayName: string,
+  tag: number,
   props: State[] | null,
   state: State[] | null,
   children: DisplayNode[] | null,
-  tag: number,
 }
 
 export interface State {

--- a/extension/backend/interfaces.ts
+++ b/extension/backend/interfaces.ts
@@ -1,9 +1,10 @@
-export interface FiberNode {
+export interface DisplayNode {
   id: number,
   displayName: string,
   props: State[] | null,
   state: State[] | null,
-  children: FiberNode[] | null,
+  children: DisplayNode[] | null,
+  tag: number,
 }
 
 export interface State {

--- a/extension/inject.ts
+++ b/extension/inject.ts
@@ -11,5 +11,6 @@ messageToContentScript({
 
 // Feel free to remove when there is more code...
 // console.log("hello from the injection site!");
-initialHook();
 
+// Get data from React dev tools
+initialHook();

--- a/extension/inject.ts
+++ b/extension/inject.ts
@@ -1,4 +1,4 @@
-import { initialHook } from './initialHook';
+import { initialHook } from './backend/initialHook';
 
 function messageToContentScript(message) {
   window.postMessage(message, "*");
@@ -10,6 +10,6 @@ messageToContentScript({
 });
 
 // Feel free to remove when there is more code...
-console.log("hello from the injection site!");
-initialHook(); 
+// console.log("hello from the injection site!");
+initialHook();
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@ const path = require('path');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 module.exports = {
+  watch: true,
   entry: {
     bundle: './extension/index.ts',
     devtools: './extension/devtools.ts',
@@ -11,10 +12,10 @@ module.exports = {
   },
   plugins: [
     new CopyWebpackPlugin([
-        { from: 'extension/manifest.json', to: 'manifest.json' },
-        { from: 'extension/devtools.html', to: 'devtools.html' },
-        { from: 'extension/panel.html', to: 'panel.html' },
-      ]),
+      { from: 'extension/manifest.json', to: 'manifest.json' },
+      { from: 'extension/devtools.html', to: 'devtools.html' },
+      { from: 'extension/panel.html', to: 'panel.html' },
+    ]),
   ],
   mode: 'development',
   devtool: 'inline-source-map',


### PR DESCRIPTION
Finished:
- Created an interface for DisplayNodes and the Sate / props held by those nodes
- Converted the dual linked lists of the FiberNodes into a single array child nodes
- Added a folder for backend scripts

To do:
- Populate state and props of DisplayNodes
- Send data to content scripts from injected script
- Send that data, and only that data, to background and then to dev tools
- Render the data