### PR TITLE
Prop selection bug fixes

### DIFF
--- a/extension/frontend/App.jsx
+++ b/extension/frontend/App.jsx
@@ -77,11 +77,10 @@ class App extends Component {
   selectProp(prop) {
     // Reset results from previous selection
     resetDisplayWeights(this.state.data);
-    console.log("this prop in right panel is being hit ")
     // top level method needed before we invoke match and highest. This method allows children to connect with parents. Runs through 
     assignChildren(this.state.data);
-    // find highest runs cb match state on stateful comoponent 
-    const topNode = findHighestState(this.state.clickedNode, prop, matchState);
+    // find highest runs cb match state on stateful comoponent , if there is no highest stateful componenet with that info then start traversing at root
+    const topNode = findHighestState(this.state.clickedNode, prop, matchState) || this.state.data;
     traverseData(topNode, prop, matchProps);
     this.setState({
       data: this.state.data,

--- a/extension/frontend/organizers.ts
+++ b/extension/frontend/organizers.ts
@@ -46,6 +46,8 @@ const iterateMediums = (node: DisplayNode): void => {
 };
 
 export const matchProps = (node: DisplayNode, targetProp: State) => {
+  // if the prop value of the selected node is null then return 
+  if (!node.props) return;
   for (const prop of node.props) {
     if (prop.key === targetProp.key) {
       node.displayWeight = Math.max(.5, node.displayWeight);


### PR DESCRIPTION
Issues:
- When querying for a prop, any components without props would cause an error
- Querying for props not derived from state would lead to an error

Fixes:
-  traverseData now checks that a node's prop value is not null before iterating through its values
- topNode now defaults to the root node of the tree when findHeighestState does not return a node