### PR TITLE
Algorithms Refactor

### DIFF
--- a/extension/algorithms/dataConversion.ts
+++ b/extension/algorithms/dataConversion.ts
@@ -1,0 +1,138 @@
+import { DisplayNode, State } from "../backend/interfaces";
+import Traverse from "./dataTraversal";
+
+// this function converts fibernode to display node and populates the children and sibling arrays recursively 
+export const fiberNodeToTree = (fiberNode) => {
+  // Convert dual linked list structure into graph
+  // Create a new node
+  const convertedNode = convertToDisplayNode(fiberNode);
+  // Add child and child's siblings to array
+  let childNode = fiberNode.child;
+  while (childNode) {
+    convertedNode.children.push(fiberNodeToTree(childNode));
+    childNode = childNode.sibling;
+  }
+  // Return converted node
+  return convertedNode
+};
+
+export const connectToParent = (node: DisplayNode) => {
+  for (const child of node.children) {
+    child.parent = node;
+    connectToParent(child);
+  }
+};
+
+// declare function that will return obj with the structure of each indiviual node saved from fiber 
+const convertToDisplayNode = (node): DisplayNode => {
+  return {
+    id :checkDebug(node),
+    tag: node.tag,
+    name: assignName(node),
+    type: assignType(node),
+    state: convertState(node),
+    props: convertProps(node),
+    parent: null,
+    children: [],
+    displayName: null,
+    displayWeight: 0,
+    mediums: [],
+  }
+}
+
+// will create structure of state that we take from fiber 
+const convertState = (node): State => {
+  if (!node.memoizedState) return null;
+  return {
+    key: 'State',
+    // Spread operator prevents unwanted circular references
+    value: { ...node.memoizedState },
+    type: (node.memoizedState.memoizedState && node._debugHookTypes[0] === 'useState') ? 'hook' : 'componentState',
+    topComponent: null,
+    components: null,
+  }
+};
+
+// Assigns name of component to simpleNode
+// (Need to add in all cases?)
+const assignName = (node): any => {
+  // Find name of a class component
+  if (node.type && node.type.name) return node.type.name;
+  // Find a functional component
+  if (node.tag === 0) return 'FC';
+  // Tag 5 === HostComponent
+  if (node.tag === 5) return `${node.type}`;
+  // Tag 3 === HostRoot 
+  if (node.tag === 3) return 'HR';
+  // Tag 3 === HostText
+  if (node.tag === 6) {
+    return node.memoizedProps;
+  }
+  if (node.tag === 7) return "Fragment";
+};
+
+// Component Types
+const componentTypes = {
+  0: 'Functional Component',
+  1: 'Class Component',
+  2: 'Indeterminate Component',
+  3: 'Host Root',
+  4: 'Host Portal',
+  5: 'Host Component',
+  6: 'Host Text',
+  7: 'Fragment',
+  8: 'Mode',
+  9: 'Context Consumer',
+  10: 'Context Provider',
+  11: 'ForwardRef',
+  12: 'Profiler',
+  13: 'Suspense Component',
+  14: 'Memo Component',
+  15: 'Simple Memo Component',
+  16: 'Lazy Component'
+};
+
+// Assigns type of component to simpleNode
+const assignType = (node): any => {
+  // Check if tag is equal to key in componentTypes and return value
+  return componentTypes[node.tag];
+};
+
+// Check for debug id\
+// NEED TO FIX THIS STILL
+const checkDebug = (node): number => {
+  if (node._debugID) return node._debugID;
+  return 0;
+};
+
+// PROPS
+// memoizedProps will be an object of key/value pairs of props
+// We can also check tag to check for what type of component it is
+
+const convertProps = (node) => {
+  // Check if node has props
+  // If not return null
+  if (!node.memoizedProps) return null;
+  // Create props array
+  const props: State[] = [];
+  // Iterate through memoizedProps.props
+  for (const key in node.memoizedProps) {
+    try {
+      // Create a prop object
+      const prop: State = {
+        // Store values in object
+        key,
+        value: node.memoizedProps[key],
+        topComponent: null,
+        components: [],
+        type: 'prop',
+      };
+      // Push object to props array
+      props.push(prop);
+    } catch (error) {
+      continue;
+    }
+  }
+  // Return props array
+  return props;
+};

--- a/extension/algorithms/dataTraversal.ts
+++ b/extension/algorithms/dataTraversal.ts
@@ -1,0 +1,21 @@
+import { DisplayNode } from "../backend/interfaces";
+
+export default class Traverse {
+
+  static upward(targetNode: DisplayNode | null, callback: Function, ...args: any): void {
+    while(targetNode) {
+      const result = callback(targetNode, ...args);
+      if (result) return;
+      targetNode = targetNode.parent;
+    }
+  }
+
+  static downward(startNode: DisplayNode, callback: Function, ...args: any): void {
+    for (const childNode of startNode.children) {
+      const result = callback(childNode, ...args);
+      if (result) return;
+      this.downward(childNode, callback, ...args);
+    }
+  }
+  
+}

--- a/extension/algorithms/nodeCategorization.ts
+++ b/extension/algorithms/nodeCategorization.ts
@@ -1,0 +1,95 @@
+import { DisplayNode, State } from "../backend/interfaces";
+import Traverse from "./dataTraversal";
+
+export default class FindProp {
+  
+  static inState (targetNode: DisplayNode, targetProp: State): void {
+    /*
+      Searches through the entirety of State obj on a display node, both keys and values, 
+      to find the value from a selected prop of clicked displayNode
+    */
+
+    // dec a func to actually do the traversing up 
+    const crawler = (stateValue: any, propValue: any): void =>{
+      if (typeof stateValue === 'object') {
+        // Check that propValue is an object and propValue and stateValue are either both array or neither are arrays
+        if (typeof propValue === 'object' && Array.isArray(stateValue) === Array.isArray(propValue)){
+          // compare stringified
+          if(JSON.stringify(propValue) === JSON.stringify(stateValue)) {
+            // increment the displayWeight of the node 
+            // Math max says that if the value is higher than 1 return the higher value 
+            targetNode.displayWeight = Math.max(1, targetNode.displayWeight);
+          }
+        }
+        for (const key in stateValue) {
+          // Compare propValue to each key in stateValue
+          if (key == propValue) targetNode.displayWeight = Math.max(0.5, targetNode.displayWeight);
+          // Run crawler on each element in stateValue
+          crawler(stateValue[key], propValue);
+        }
+      } else {
+        // If stateValue is primitive, compare stateValue to propValue
+        if (stateValue === propValue) targetNode.displayWeight = Math.max(1, targetNode.displayWeight);
+      }
+    }
+    //invoke with params (node higher on the tree than clicked nodes state value and the prop from the clickedNode 
+    crawler(targetNode.state.value, targetProp.value); 
+  }
+
+  static inProps (targetNode: DisplayNode, targetProp: State): void {
+    if (!targetNode.props) return;
+    for (const prop of targetNode.props) {
+      if (prop.key === targetProp.key) {
+        targetNode.displayWeight = Math.max(.5, targetNode.displayWeight);
+        if (prop.value === targetProp.value) targetNode.displayWeight = Math.max(1, targetNode.displayWeight);
+      }
+    }
+  }
+
+}
+
+// to create paths between startnode and the top stateful node 
+export const createPathToRoot = (startNode: DisplayNode): DisplayNode[] => {
+  // Create an array of stateful nodes
+  const statefulNodeArr: DisplayNode[] = [];
+  // Create an array of intermediary nodes, put startNode in med arr first because we dont want to count startNode as its own parent with same props 
+  let mediums: DisplayNode[] = [startNode];
+  // Traverse up the node tree
+  Traverse.upward(startNode.parent, (currentNode: DisplayNode) => {
+    // if it is stateful then push it to the stateful array 
+    if(currentNode.state) {
+      // push the current node so that we can find top of the chain 
+      statefulNodeArr.push(currentNode)
+      // push exisiting mediums we have kept into the top stateful node we found 
+      currentNode.mediums = [...mediums];
+      // reset mediums to include the current node mimicing what we did on 55  
+      mediums = [currentNode];
+    // else push to intermediary array 
+    } else {
+      mediums.push(currentNode);
+    }
+  });
+  // Return the array of stateful nodes
+  return statefulNodeArr;
+};
+
+// will change the display weight of all stateful component and path weights of all the mediums 
+export const workOnStatefulNodes = (nodes: DisplayNode[], prop: State): DisplayNode => {
+  // dec var for highest stateful node that has the props 
+  let highestNodeWithTarget: null | DisplayNode = null ; 
+  // iterate through the stateful nodes in reverse, from heighest to lowest
+  for(let i = nodes.length - 1; i >= 0; i--) {
+    // invoke FindProp.inState passing in statefulnode, this will see if the stateful node has the desired props 
+    FindProp.inState(nodes[i], prop);
+    // Check if the node has the prop and highestNodeWithTarget is null, if null assign highest to curr node 
+    if (nodes[i].displayWeight && !highestNodeWithTarget) highestNodeWithTarget = nodes[i];
+    // iterate through the mediums 
+    nodes[i].mediums.forEach((el) => {
+      // if display weight is 0 then set pathweight of medium to be equal to stateful node's path weight 
+      // Note: Replace first and last displayWeight with pathWeight for production
+      el.displayWeight = nodes[i].displayWeight || nodes[i].displayWeight;
+    });
+  }
+  // Return the heighest stateful node that contains the props or return null if there are no stateful nodes
+  return highestNodeWithTarget;
+};


### PR DESCRIPTION
Finished:

**dataTraversal**
- traverseData was replaced
- The Traverse class contains two methods
- Traverse.downward performs a callback function on each node under a specified starting node
   - Additional arguments can be passed to the callback function
   - When the callback function returns a truthy value, the traversal is ended
   - This method replaces traverseData
- Traverse.upward performs a callback on every node above a specified starting node along the parent chain
   - Additional arguments can be passed to the callback function
   - When the callback function returns a truthy value, the traversal is ended

**dataConversion**
- dataCollection was replaced and refactored
- The helper functions from dataCollection were migrated to dataConversion
- The SimpleNode class was replaced with a function, convertToDisplayNode
- convertStructure was replaced with fiberNodeToTree
- Some of the code in fiberNodeToTree was simplified
- AssignChildren was replaced with connectToParent

**nodeCategorization**
- findHeighestNode was performing multiple tasks, replaced with createPathToRoot and workOnStatefulNodes
- createPathToRoot assigns nodes between and including a starting node to the mediums array of the first stateful node above them and returns an array of stateful nodes between the starting node and the root node of a tree
- workOnStateFulNodes iterates through an array of stateful components and checks if they have a specific prop in their state with FindProp.inState and assigns a displayWeight to their mediums before returning the highest stateful node that contains the prop 

To do:
- Implement these changes in the application
- Create tests to ensure that these changes do not break the application
- Change workOnStatefulNodes to alter the pathWeight of each medium node rather than the displayWeight