### PR TITLE
Circular Bug Fix

### DIFF
--- a/extension/algorithms/dataConversion.ts
+++ b/extension/algorithms/dataConversion.ts
@@ -49,7 +49,7 @@ const convertState = (node): Prop => {
   return {
     key: 'State',
     // Spread operator prevents unwanted circular references
-    value: { ...node.memoizedState },
+    value: JSON.parse(JSON.stringify(node.memoizedState)),
     type: (node.memoizedState.memoizedState && node._debugHookTypes[0] === 'useState') ? 'hook' : 'componentState',
   }
 };
@@ -123,7 +123,8 @@ const convertProps = (node) => {
       const prop: Prop = {
         // Store values in object
         key,
-        value: node.memoizedProps[key],
+        // Create a clone of the prop value to preserve composet values
+        value: JSON.parse(JSON.stringify(node.memoizedProps[key])),
         type: 'prop',
       };
       // Push object to props array

--- a/extension/algorithms/nodeCategorization.ts
+++ b/extension/algorithms/nodeCategorization.ts
@@ -42,6 +42,11 @@ class FindProp {
       if (prop.key === targetProp.key) {
         targetNode.displayWeight = Math.max(.5, targetNode.displayWeight);
         if (prop.value === targetProp.value) targetNode.displayWeight = Math.max(1, targetNode.displayWeight);
+        if (typeof targetProp.value === 'object' && typeof prop.value === 'object') {
+          if (JSON.stringify(prop.value) === JSON.stringify(targetProp.value)) {
+            targetNode.displayWeight = Math.max(1, targetNode.displayWeight);
+          }
+        }
       }
     }
   }

--- a/extension/backend/initialHook.ts
+++ b/extension/backend/initialHook.ts
@@ -1,5 +1,4 @@
 const { fiberNodeToTree } = require('../algorithms/dataConversion');
-const circle = require('circular');
 
 declare global {
   interface Window {
@@ -17,8 +16,7 @@ export const initialHook = () => {
     devTools.onCommitFiberRoot = (function (original) {
       return function (...args) {
         const fiberNode = args[1].current;
-        const message = JSON.parse(JSON.stringify(fiberNodeToTree(fiberNode), circle()));
-        window.postMessage({ message, id: 'ReactFLO' }, '*');
+        window.postMessage({ message: fiberNodeToTree(fiberNode), id: 'ReactFLO' }, '*');
 
         return original(...args);
       };


### PR DESCRIPTION
Issues:
- Composite data types were being converted to string "[Circular]" during data conversion
- Composite data types could not be accurately queried using FindProp.inProps

Fixes:
- Props and State are being deep copied before being attached to Display Nodes
- FindProp.inProps checks for composite data types
- InitialHook no longer makes use of circular to send data